### PR TITLE
fix: resolve Android build and theme compatibility issues

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 android {
     namespace = "com.example.returnly_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"  // Fixed: Updated to the required NDK version
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -56,7 +56,7 @@ final ThemeData lightMode = ThemeData.light().copyWith(
   ),
 
   // Card styling (same as background or change if you like)
-  cardTheme: CardTheme(
+  cardTheme: CardThemeData(
     color: const Color(0xFFFEFAF6),
     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
     elevation: 0,
@@ -117,7 +117,7 @@ final ThemeData darkMode = ThemeData.dark().copyWith(
     ),
   ),
 
-  cardTheme: CardTheme(
+  cardTheme: CardThemeData(
     color: Colors.grey[850],
     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
     elevation: 2,


### PR DESCRIPTION
- Update Android NDK version to 27.0.12077973 for Firebase plugin compatibility
- Fix CardTheme API usage by changing to CardThemeData for Flutter compatibility
- Ensure CI/CD pipeline builds successfully with latest dependencies

Resolves GitHub Actions build failures:
- NDK version mismatch with Firebase plugins
- Deprecated CardTheme constructor usage