### PR TITLE
Fix auth navigation flow and error handling

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -27,7 +27,6 @@ class AppRouter {
         path: '/splash',
         builder: (context, state) => const SplashScreen(),
       ),
-
       GoRoute(
         path: '/login',
         builder: (context, state) => const LoginScreen(),

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
@@ -16,9 +17,23 @@ class _LoginScreenState extends State<LoginScreen> {
   final _pwCtrl = TextEditingController();
   bool _obscurePw = true;
   bool _isLoading = false;
+  StreamSubscription<User?>? _authSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    // Listen to auth state changes and redirect when user signs in
+    _authSubscription = FirebaseAuth.instance.authStateChanges().listen((user) {
+      if (user != null && mounted) {
+        // User signed in, navigate to home
+        context.go('/');
+      }
+    });
+  }
 
   @override
   void dispose() {
+    _authSubscription?.cancel();
     _emailCtrl.dispose();
     _pwCtrl.dispose();
     super.dispose();
@@ -26,28 +41,44 @@ class _LoginScreenState extends State<LoginScreen> {
 
   Future<void> _signIn() async {
     setState(() => _isLoading = true);
+
     try {
       await FirebaseAuth.instance.signInWithEmailAndPassword(
         email: _emailCtrl.text.trim(),
         password: _pwCtrl.text,
       );
-      if (!mounted) return;
-      setState(() => _isLoading = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Log In successful!')),
-      );
-      context.go('/');
+      // Don't navigate here - let the auth state listener handle it
+
     } on FirebaseAuthException catch (e) {
       if (!mounted) return;
       setState(() => _isLoading = false);
+
+      String errorMessage = 'Sign in failed';
+      switch (e.code) {
+        case 'user-not-found':
+          errorMessage = 'No user found for that email.';
+          break;
+        case 'wrong-password':
+          errorMessage = 'Wrong password provided.';
+          break;
+        case 'invalid-email':
+          errorMessage = 'Invalid email address.';
+          break;
+        case 'user-disabled':
+          errorMessage = 'This account has been disabled.';
+          break;
+        default:
+          errorMessage = e.message ?? 'Sign in failed';
+      }
+
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(e.message ?? 'Sign In error')),
+        SnackBar(content: Text(errorMessage)),
       );
     } catch (e) {
       if (!mounted) return;
       setState(() => _isLoading = false);
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('An unexpected error occurred during Sign In')),
+        const SnackBar(content: Text('An unexpected error occurred')),
       );
     }
   }
@@ -62,7 +93,6 @@ class _LoginScreenState extends State<LoginScreen> {
       body: SafeArea(
         child: Column(
           children: [
-            // Scrollable content
             Expanded(
               child: SingleChildScrollView(
                 child: Padding(
@@ -71,7 +101,7 @@ class _LoginScreenState extends State<LoginScreen> {
                     children: [
                       const SizedBox(height: 20),
 
-                      // Logo Container - Fixed position
+                      // Logo Container
                       Container(
                         height: 160,
                         width: double.infinity,
@@ -119,7 +149,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
                       const SizedBox(height: 40),
 
-                      // Title and Subtitle - Fixed position
+                      // Title and Subtitle
                       Align(
                         alignment: Alignment.centerLeft,
                         child: Column(
@@ -145,9 +175,9 @@ class _LoginScreenState extends State<LoginScreen> {
 
                       const SizedBox(height: 32),
 
-                      // Form Fields Container - Fixed height to accommodate all forms
+                      // Form Fields
                       SizedBox(
-                        height: 200, // Fixed height for consistent button positioning
+                        height: 200,
                         child: Column(
                           children: [
                             // Email Field
@@ -199,9 +229,9 @@ class _LoginScreenState extends State<LoginScreen> {
                               ),
                             ),
 
-                            const Spacer(), // This pushes the button to stay in consistent position
+                            const Spacer(),
 
-                            // Sign In Button - Will be in same position as Get Started button
+                            // Sign In Button
                             SizedBox(
                               width: double.infinity,
                               height: 50,
@@ -239,9 +269,9 @@ class _LoginScreenState extends State<LoginScreen> {
 
                       const SizedBox(height: 16),
 
-                      // Forgot Password Link - Fixed position
+                      // Forgot Password Link
                       SizedBox(
-                        height: 40, // Fixed height for consistent spacing
+                        height: 40,
                         child: TextButton(
                           onPressed: () => context.go('/forgot_password'),
                           child: Text(
@@ -259,7 +289,7 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
             ),
 
-            // Fixed Bottom Section
+            // Bottom Navigation
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 20),
               child: Container(

--- a/lib/screens/auth/signup_screen.dart
+++ b/lib/screens/auth/signup_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -19,9 +20,23 @@ class _SignupScreenState extends State<SignupScreen> {
   bool _obscurePw = true;
   bool _obscureConfirm = true;
   bool _isLoading = false;
+  StreamSubscription<User?>? _authSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    // Listen to auth state changes and redirect when user signs up
+    _authSubscription = FirebaseAuth.instance.authStateChanges().listen((user) {
+      if (user != null && mounted) {
+        // User signed up, navigate to home
+        context.go('/');
+      }
+    });
+  }
 
   @override
   void dispose() {
+    _authSubscription?.cancel();
     _usernameCtrl.dispose();
     _emailCtrl.dispose();
     _pwCtrl.dispose();
@@ -54,18 +69,12 @@ class _SignupScreenState extends State<SignupScreen> {
           'createdAt': FieldValue.serverTimestamp(),
         });
       }
-      if (!mounted) return;
-      setState(() => _isLoading = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Sign Up successful!')),
-      );
-      context.go('/'); // navigate to home
+      // Don't navigate here - let the auth state listener handle it
     } on FirebaseAuthException catch (e) {
       if (mounted) setState(() => _isLoading = false);
       ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text(e.message ?? 'Sign-up failed')));
     } catch (e) {
-      print(e);
       if (mounted) setState(() => _isLoading = false);
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('An unexpected error occurred during Sign Up')),

--- a/lib/services/auth_gate.dart
+++ b/lib/services/auth_gate.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:go_router/go_router.dart';
 import 'package:returnly_app/screens/auth/login_screen.dart';
 import 'package:returnly_app/screens/home/home_screen.dart';
 
@@ -10,19 +9,12 @@ class AuthGate extends StatelessWidget {
 
   Future<Map<String, dynamic>?> fetchUserProfile(String uid) async {
     try {
-      // If user IDs are Firestore doc IDs:
       final doc = await FirebaseFirestore.instance.collection('users').doc(uid).get();
       if (doc.exists) {
         return doc.data();
       }
-      // If using a 'uid' field in your documents instead of doc IDs:
-      // final snap = await FirebaseFirestore.instance.collection('users').where('uid', isEqualTo: uid).limit(1).get();
-      // if (snap.docs.isNotEmpty) {
-      //   return snap.docs.first.data();
-      // }
       return null;
     } catch (e) {
-      print('Error fetching user profile: $e');
       return null;
     }
   }
@@ -32,32 +24,47 @@ class AuthGate extends StatelessWidget {
     return StreamBuilder<User?>(
       stream: FirebaseAuth.instance.authStateChanges(),
       builder: (context, snapshot) {
-        // Show loading spinner while waiting
+        // Show loading while checking auth state
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator());
+          return const Scaffold(
+            backgroundColor: Color(0xFFFEFAF6),
+            body: Center(
+              child: CircularProgressIndicator(
+                color: Color(0xFF102C57),
+              ),
+            ),
+          );
         }
 
-        // User is logged in
-        if (snapshot.hasData && snapshot.data != null) {
-          final user = snapshot.data!;
-          // Here you can use a FutureBuilder if you want to fetch user profile from Firestore:
+        // Handle auth state errors
+        if (snapshot.hasError) {
+          return const LoginScreen();
+        }
+
+        final user = snapshot.data;
+
+        // User is authenticated
+        if (user != null) {
           return FutureBuilder<Map<String, dynamic>?>(
             future: fetchUserProfile(user.uid),
-            builder: (context, profileSnap) {
-              if (profileSnap.connectionState == ConnectionState.waiting) {
-                return const Center(child: CircularProgressIndicator());
+            builder: (context, profileSnapshot) {
+              if (profileSnapshot.connectionState == ConnectionState.waiting) {
+                return const Scaffold(
+                  backgroundColor: Color(0xFFFEFAF6),
+                  body: Center(
+                    child: CircularProgressIndicator(
+                      color: Color(0xFF102C57),
+                    ),
+                  ),
+                );
               }
-              if (profileSnap.hasError) {
-                return Center(child: Text('Error loading profile'));
-              }
-              // Pass the profile data to your HomeScreen if needed
-              // You could also create a user model from profileSnap.data if you want
+
               return HomeScreen(user: user);
             },
           );
         }
 
-        // User is NOT logged in
+        // User is not authenticated
         return const LoginScreen();
       },
     );

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -39,7 +37,6 @@ class AuthService extends ChangeNotifier {
       notifyListeners();
       return result;
     } catch (e) {
-      print("something went wrong while signing up: $e");
       rethrow;
     }
   }
@@ -57,7 +54,6 @@ class AuthService extends ChangeNotifier {
       notifyListeners();
       return result;
     } catch (e) {
-      print('Sign in error: $e');
       rethrow;
     }
   }
@@ -68,7 +64,6 @@ class AuthService extends ChangeNotifier {
       await _auth.signOut();
       notifyListeners();
     } catch (e) {
-      print('Sign out error: $e');
       rethrow;
     }
   }
@@ -78,9 +73,7 @@ class AuthService extends ChangeNotifier {
     try {
       await _auth.sendPasswordResetEmail(email: email);
     } catch (e) {
-      print('Reset password error: $e');
       rethrow;
     }
   }
-  
 }


### PR DESCRIPTION
- Add auth state listeners to login/signup screens
- Remove manual navigation after sign-in/sign-up
- Let Firebase auth state changes handle automatic redirect
- Clean up auth service and remove debug code
- Fix StreamSubscription disposal for memory leaks

Fixes: Sign-in error and navigation not redirecting to home